### PR TITLE
Enable displayName for LazyViews

### DIFF
--- a/src/Fable.Elmish.React.fsproj
+++ b/src/Fable.Elmish.React.fsproj
@@ -8,7 +8,7 @@
     <Compile Include="react-native.fs" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="*.fsproj; *.fs" PackagePath="fable\" />
+    <Content Include="*.fsproj; *.fs; *.js" PackagePath="fable\" />
   </ItemGroup>
   <Import Project="..\.paket\Paket.Restore.targets" />
 </Project>

--- a/src/common.fs
+++ b/src/common.fs
@@ -13,6 +13,11 @@ type LazyProps<'model> = {
 }
 
 module Components =
+    open Fable.Core.JsInterop
+
+    let internal createLazyView (displayName: string): ComponentClass<LazyProps<'model>> =
+        importMember "./util.js"
+
     type LazyView<'model>(props) =
         inherit Component<LazyProps<'model>,obj>(props)
 
@@ -24,10 +29,50 @@ module Components =
 
 [<AutoOpen>]
 module Common =
+    /// Build a React component that avoids rendering the view unless the model has changed.
+    /// Store the result of applying the first argument and use it in your render function. Example:
+    /// ```
+    ///     let hello = lazyViewBuilder "Hello"
+    ///     let render model =
+    ///        hello equal view state
+    /// ```
+    /// * displayName: name to be displayed in React dev tools
+    /// * equal: function to compare the previous and the new states
+    /// * view: function to render the model
+    /// * state: new state to render
+    let lazyViewBuilder (displayName: string) =
+        let com = Components.createLazyView displayName
+        fun (equal:'model->'model->bool) (view:'model->ReactElement) (state:'model) ->
+            from com { render = fun () -> view state
+                       equal = equal
+                       model = state } []
+
+    /// Build a React component that avoids rendering the view unless the model has changed.
+    /// Store the result of applying the first argument and use it in your render function. Example:
+    /// ```
+    ///     let hello = lazyView2Builder "Hello"
+    ///     let render model =
+    ///        hello equal view state dispatch
+    /// ```
+    /// * displayName: name to be displayed in React dev tools
+    /// * equal: function to compare the previous and the new states
+    /// * view: function to render the model using the dispatch
+    /// * state: new state to render
+    /// * dispatch: dispatch function
+    let lazyView2Builder (displayName: string) =
+        let com = Components.createLazyView displayName
+        fun (equal:'model->'model->bool)
+             (view:'model->'msg Dispatch->ReactElement)
+             (state:'model)
+             (dispatch:'msg Dispatch) ->
+            from com { render = fun () -> view state dispatch
+                       equal = equal
+                       model = state } []
+
     /// Avoid rendering the view unless the model has changed.
-    /// equal: function to compare the previous and the new states
-    /// view: function to render the model
-    /// state: new state to render
+    /// * equal: function to compare the previous and the new states
+    /// * view: function to render the model
+    /// * state: new state to render
     let lazyViewWith (equal:'model->'model->bool)
                      (view:'model->ReactElement)
                      (state:'model) =
@@ -38,10 +83,10 @@ module Common =
             []
 
     /// Avoid rendering the view unless the model has changed.
-    /// equal: function to compare the previous and the new states
-    /// view: function to render the model using the dispatch
-    /// state: new state to render
-    /// dispatch: dispatch function
+    /// * equal: function to compare the previous and the new states
+    /// * view: function to render the model using the dispatch
+    /// * state: new state to render
+    /// * dispatch: dispatch function
     let lazyView2With (equal:'model->'model->bool)
                       (view:'model->'msg Dispatch->ReactElement)
                       (state:'model)
@@ -53,12 +98,16 @@ module Common =
             []
 
     /// Avoid rendering the view unless the model has changed.
-    /// equal: function to compare the previous and the new model (a tuple of two states)
-    /// view: function to render the model using the dispatch
-    /// state1: new state to render
-    /// state2: new state to render
-    /// dispatch: dispatch function
-    let lazyView3With (equal:_->_->bool) (view:_->_->_->ReactElement) state1 state2 (dispatch:'msg Dispatch) =
+    /// * equal: function to compare the previous and the new model (a tuple of two states)
+    /// * view: function to render the model using the dispatch
+    /// * state1: new state to render
+    /// * state2: new state to render
+    /// * dispatch: dispatch function
+    let lazyView3With (equal:('model1*'model2)->('model1*'model2)->bool)
+                      (view:'model1->'model2->'msg Dispatch->ReactElement)
+                      (state1:'model1)
+                      (state2:'model2)
+                      (dispatch:'msg Dispatch) =
         ofType<Components.LazyView<_>,_,_>
             { render = fun () -> view state1 state2 dispatch
               equal = equal
@@ -66,18 +115,16 @@ module Common =
             []
 
     /// Avoid rendering the view unless the model has changed.
-    /// view: function of model to render the view
+    /// * view: function of model to render the view
     let lazyView (view:'model->ReactElement) =
         lazyViewWith (=) view
 
     /// Avoid rendering the view unless the model has changed.
-    /// view: function of two arguments to render the model using the dispatch
+    /// * view: function of two arguments to render the model using the dispatch
     let lazyView2 (view:'model->'msg Dispatch->ReactElement) =
         lazyView2With (=) view
 
     /// Avoid rendering the view unless the model has changed.
     /// view: function of three arguments to render the model using the dispatch
-    let lazyView3 (view:_->_->_->ReactElement) =
+    let lazyView3 (view:'model1->'model2->'msg Dispatch->ReactElement) =
         lazyView3With (=) view
-
-

--- a/src/react.fs
+++ b/src/react.fs
@@ -57,13 +57,13 @@ module Program =
 
     /// Setup rendering of root React component inside html element identified by placeholderId
     let withReact placeholderId (program:Elmish.Program<_,_,_,_>) =
-        Internal.withReactUsing (lazyView2Builder "ElmishRoot") placeholderId program
+        Internal.withReactUsing lazyView2With placeholderId program
 
     /// `withReact` uses `requestAnimationFrame` to optimize rendering in scenarios with updates at a higher rate than 60FPS, but this makes the cursor jump to the end in `input` elements.
     /// This function works around the glitch if you don't need the optimization (see https://github.com/elmish/react/issues/12).
     let withReactUnoptimized placeholderId (program:Elmish.Program<_,_,_,_>) =
-        Internal.withReactUnoptimizedUsing (lazyView2Builder "ElmishRoot") placeholderId program
+        Internal.withReactUnoptimizedUsing lazyView2With placeholderId program
 
     /// Setup rendering of root React component inside html element identified by placeholderId using React.hydrate
     let withReactHydrate placeholderId (program:Elmish.Program<_,_,_,_>) =
-        Internal.withReactHydrateUsing (lazyView2Builder "ElmishRoot") placeholderId program
+        Internal.withReactHydrateUsing lazyView2With placeholderId program

--- a/src/react.fs
+++ b/src/react.fs
@@ -57,13 +57,13 @@ module Program =
 
     /// Setup rendering of root React component inside html element identified by placeholderId
     let withReact placeholderId (program:Elmish.Program<_,_,_,_>) =
-        Internal.withReactUsing lazyView2With placeholderId program
+        Internal.withReactUsing (lazyView2Builder "ElmishRoot") placeholderId program
 
     /// `withReact` uses `requestAnimationFrame` to optimize rendering in scenarios with updates at a higher rate than 60FPS, but this makes the cursor jump to the end in `input` elements.
     /// This function works around the glitch if you don't need the optimization (see https://github.com/elmish/react/issues/12).
     let withReactUnoptimized placeholderId (program:Elmish.Program<_,_,_,_>) =
-        Internal.withReactUnoptimizedUsing lazyView2With placeholderId program
+        Internal.withReactUnoptimizedUsing (lazyView2Builder "ElmishRoot") placeholderId program
 
     /// Setup rendering of root React component inside html element identified by placeholderId using React.hydrate
     let withReactHydrate placeholderId (program:Elmish.Program<_,_,_,_>) =
-        Internal.withReactHydrateUsing lazyView2With placeholderId program
+        Internal.withReactHydrateUsing (lazyView2Builder "ElmishRoot") placeholderId program

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,17 @@
+import * as React from "react";
+
+export function createLazyView(displayName) {
+    const LazyView = class extends React.Component {
+        constructor(props) {
+            super(props);
+        }
+        shouldComponentUpdate(nextProps, _nextState) {
+            return !this.props.equal(this.props.model, nextProps.model);
+        }
+        render() {
+            return this.props.render();
+        }
+    };
+    LazyView.displayName = displayName || "LazyView";
+    return LazyView;
+}

--- a/src/util.js
+++ b/src/util.js
@@ -1,17 +1,17 @@
 import * as React from "react";
 
-export function createLazyView(displayName) {
+export function createLazyView(displayName, areEqual, render) {
     const LazyView = class extends React.Component {
         constructor(props) {
             super(props);
         }
         shouldComponentUpdate(nextProps, _nextState) {
-            return !this.props.equal(this.props.model, nextProps.model);
+            return !areEqual(this.props.model, nextProps.model);
         }
         render() {
-            return this.props.render();
+            return render(this.props.state, this.props.dispatch);
         }
     };
     LazyView.displayName = displayName || "LazyView";
-    return LazyView;
+    return ([key, model, dispatch]) => React.createElement(LazyView, { key, model, dispatch });
 }


### PR DESCRIPTION
Sorry, I should have sent this earlier but after seeing @MangelMaxime's PR I thought this could be a good opportunity to fix the display names of Lazy View in React dev tools. I'm sending this proposal that uses JS to create class expressions so we can edit the display name. I'm not using the new `React.memo` so Fable.Elmish.React remains compatible with older React versions.

I've tried to keep the same API, but given the new `withReactUsing` have just been released maybe we could change them a bit to change the signature of the lazyView builders. The main problem right now is the users needs to remember to store the result after applying the first argument.

Open to discussion :) cc @vbfox

```fsharp
let hello = lazyViewBuilder "Hello"
let render model =
    hello equal view state
```

![image](https://user-images.githubusercontent.com/8275461/48418622-06aced00-e756-11e8-8566-568732c042dd.png)
