### PR TITLE
Fix `withReactNative` for Fable 2

### DIFF
--- a/src/react-native.fs
+++ b/src/react-native.fs
@@ -42,7 +42,7 @@ module Program =
 
     /// Setup rendering of root ReactNative component
     let withReactNative appKey (program:Program<_,_,_,_>) =
-        AppRegistry.registerComponent(appKey, fun () -> unbox typeof<App>)
+        AppRegistry.registerComponent(appKey, fun () -> unbox JsInterop.jsConstructor<App>)
         let render m d =
              match appState with
              | Some state ->


### PR DESCRIPTION
See https://github.com/fable-compiler/Fable/issues/1709

`typeof<'T>` doesn't return the function constructor in Fable 2 anymore. `Fable.Core.JsInterop.jsConstructor<'T>` must be used instead.