### PR TITLE
Update Fable.Elmish dependency to beta-5, fixes withConsoleTrace

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### 3.0.0-beta-3
+
+* Update to latest Elmish (beta-5) to make `withConsoleTrace` work in latest Fable 3
+
 ### 3.0.0-beta-2
 
 * Fable 3 support courtesy of Alfonso

--- a/paket.lock
+++ b/paket.lock
@@ -20,13 +20,9 @@ NUGET
       FSharp.Core (>= 4.5.2) - restriction: >= netstandard2.0
     Fable.Core (3.0.0-beta-004)
       FSharp.Core (>= 4.5.2) - restriction: >= netstandard2.0
-    Fable.Elmish (3.0.0-beta-4)
-      Fable.Core (>= 2.0.2) - restriction: >= netstandard2.0
-      Fable.Promise (>= 1.0) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.5.4) - restriction: >= netstandard2.0
-    Fable.Promise (1.1) - restriction: >= netstandard2.0
-      Fable.Core (>= 2.0.2) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.5.2) - restriction: >= netstandard2.0
+    Fable.Elmish (3.0.0-beta-5)
+      Fable.Core (>= 3.0.0-beta-004) - restriction: >= netstandard2.0
+      FSharp.Core (>= 4.6.2) - restriction: >= netstandard2.0
     Fable.React (5.0.0-alpha-005)
       Fable.Browser.Dom (>= 1.0.0-alpha-003) - restriction: >= netstandard2.0
       Fable.Core (>= 2.1.0-alpha-002) - restriction: >= netstandard2.0


### PR DESCRIPTION
In my project I have:
```xml
<PackageReference Include="Fable.Core" Version="3.0.0-beta-005" />
<PackageReference Include="Fable.Elmish.React" Version="3.0.0-beta-2" />
```
Fable.Elmish.React uses `Fable.Elmish 3.0.0-beta-4` as a dependency so when I use `Program.withConsoleTrace` (coming from `Fable.Elmish`) the project doesn't compile as the `prelude.fs` file is not compatible with latest `Fable.Core`:

```fs
// Fable.Elmish Fable.Elmish 3.0.0-beta-4
module internal Log =

#if FABLE_COMPILER
    open Fable.Core.JsInterop
    open Fable.Import.JS

    let onError (text: string, ex: exn) = console.error (text,ex)
    let toConsole(text: string, o: #obj) = console.log(text,o)

#else  
```
This is fixed in `Fable.Elmish 3.0.0-beta-5`:
```fs
// Fable.Elmish 3.0.0-beta-5
module internal Log =

#if FABLE_COMPILER
    open Fable.Core.JS

    let onError (text: string, ex: exn) = console.error (text,ex)
    let toConsole(text: string, o: #obj) = console.log(text,o)

#else

```

